### PR TITLE
Meh, simplify and fix in-place remove algo

### DIFF
--- a/dfio/dfio.d
+++ b/dfio/dfio.d
@@ -278,13 +278,11 @@ void eventloop()
                     queue.push(cast(Fiber)(a.fiber));
                     i++;
                 }
-                else if(i != j) {
+                else {
                     w[j] = w[i];
                     j++;
                     i++;
                 }
-                else
-                    i++;
             }
             mtx.unlock();
             Thread.yield();


### PR DESCRIPTION
There is no harm done in just writing i -> j even if they are equal.
