### PR TITLE
Symmetric eventloop

### DIFF
--- a/dfio/dfio.d
+++ b/dfio/dfio.d
@@ -462,6 +462,7 @@ struct DescriptorState {
 
 // intercept - a filter for file descriptor, changes flags and register on first use
 void interceptFd(int fd) {
+    if (fd < 0 || fd >= descriptors.length) return;
     if (descriptors[fd].firstUse) {
         logf("First use, registering fd = %d", fd);
         int flags = fcntl(fd, F_GETFL, 0);
@@ -480,6 +481,7 @@ void interceptFd(int fd) {
 }
 
 void interceptFdNoFcntl(int fd) {
+    if (fd < 0 || fd >= descriptors.length) return;
     if (descriptors[fd].firstUse) {
         epoll_event event;
         event.events = EPOLLIN | EPOLLOUT; // TODO: most events that make sense to watch for
@@ -490,7 +492,7 @@ void interceptFdNoFcntl(int fd) {
 }
 
 void deregisterFd(int fd) {
-    descriptors[fd].firstUse = true;
+    if(fd >= 0 && fd < descriptors.length) descriptors[fd].firstUse = true;
 }
 
 // reschedule - put fiber in a wait list, and get back to scheduling loop
@@ -508,9 +510,6 @@ void startloop()
     ssize_t fdMax = sysconf(_SC_OPEN_MAX).checked;
     descriptors = cast(shared)new DescriptorState[fdMax];
     queue = new shared BlockingQueue!Fiber;
-
-    /*auto io = new Thread(&eventloop, 64*1024);
-    io.start();*/
 }
 
 size_t processEvents()

--- a/dfio/tests/compiles_n_runs.d
+++ b/dfio/tests/compiles_n_runs.d
@@ -4,7 +4,7 @@ import core.thread;
 import dfio;
 
 // run fibers until all of them terminate
-// void runUntilCompletion();
+// void runFibers();
 
 void main()
 {
@@ -12,11 +12,11 @@ void main()
 
     auto t1 = new Thread(() {
        //...
-       runUntilCompletion();
+       runFibers();
     });
     auto t2 = new Thread(() {
        //...
-       runUntilCompletion();
+       runFibers();
     });
     t1.start(); t2.start();
     t1.join();

--- a/dfio/tests/echo_server.d
+++ b/dfio/tests/echo_server.d
@@ -18,7 +18,7 @@ void server_worker(Socket client) {
     auto received = client.receive(buffer);
     if (received < 0) {
         logf("Error %d", received);
-        perror("Error after reading from client");
+        perror("Error while reading from client");
         return;
     }
     logf("Server_worker received:\n%s", buffer[0.. received]);

--- a/dfio/tests/echo_server.d
+++ b/dfio/tests/echo_server.d
@@ -13,7 +13,11 @@ void server_worker(Socket client) {
 
     logf("Started server_worker, client = %s", client);
     auto received = client.receive(buffer);
-
+    if (received < 0) {
+        logf("Error %d", received);
+        perror("Error after reading from client");
+        abort();
+    }
     logf("Server_worker received:\n%s", buffer[0.. received]);
 
     enum header =
@@ -52,9 +56,10 @@ void client(string toSend) {
 
     // TODO timeout?
     char[1024] response;
-    long len = 0;
-    while (len < 0) {
-        len = request.receive(response);
+    long len = request.receive(response);
+    if (len < 0){
+        perror("Error while reading on client");
+        abort();
     }
 
     logf("Received len = %d", len);

--- a/dfio/tests/echo_server.d
+++ b/dfio/tests/echo_server.d
@@ -52,7 +52,11 @@ void client(string toSend) {
 
     // TODO timeout?
     char[1024] response;
-    size_t len = request.receive(response);
+    long len = 0;
+    while (len < 0) {
+        len = request.receive(response);
+    }
+
     logf("Received len = %d", len);
     auto received = response[0..len];
 
@@ -62,20 +66,7 @@ void client(string toSend) {
 }
 
 void main() {
-
     startloop();
-
-    //auto wr = new Thread(() => server());
-    //wr.start();
     spawn(() => server());
-
-    Thread.sleep( dur!("seconds")( 1 ) );
-    spawn(() => client("client 1\n"));
-    spawn(() => client("client 2\n"));
-    spawn(() => client("client 3\n"));
-    spawn(() => client("client 4\n"));
-
-
-    runUntilCompletion();
-    //wr.join();
+    runFibers();
 }

--- a/dfio/tests/echo_server.d
+++ b/dfio/tests/echo_server.d
@@ -10,13 +10,16 @@ import dfio;
 
 void server_worker(Socket client) {
     char[1024] buffer;
-
+    scope(exit) {
+        client.shutdown(SocketShutdown.BOTH);
+        client.close();
+    }
     logf("Started server_worker, client = %s", client);
     auto received = client.receive(buffer);
     if (received < 0) {
         logf("Error %d", received);
         perror("Error after reading from client");
-        abort();
+        return;
     }
     logf("Server_worker received:\n%s", buffer[0.. received]);
 
@@ -25,9 +28,6 @@ void server_worker(Socket client) {
 
     string response = header ~ to!string(buffer[0..received]) ~ "\n";
     client.send(response);
-
-    client.shutdown(SocketShutdown.BOTH);
-    client.close();
 }
 
 void server() {

--- a/dfio/tests/ping_pong_fiber_half_duplex.d
+++ b/dfio/tests/ping_pong_fiber_half_duplex.d
@@ -48,7 +48,7 @@ void main() {
 
    // spawn fiber to read stuff
    spawn(() => writer(socks[1]));
-   runUntilCompletion();
+   runFibers();
    //
    wr.join();
 }

--- a/dfio/tests/ping_pong_full_duplex.d
+++ b/dfio/tests/ping_pong_full_duplex.d
@@ -68,7 +68,7 @@ void main() {
 
     // spawn fiber to read stuff
     spawn(() => readerWriter(socks1[1], socks2[1]));
-    runUntilCompletion();
+    runFibers();
     //
     wr.join();
 }

--- a/dfio/tests/ping_pong_full_duplex_n.d
+++ b/dfio/tests/ping_pong_full_duplex_n.d
@@ -81,7 +81,7 @@ void main(string[] args) {
     string s2 = "second read write\n";
     startloop();
     for(int i = 0; i < NR; i++) {
-        check(socketpair(AF_UNIX, SOCK_STREAM, 0, socks[i].ptr));
+        check(socketpair(AF_UNIX, SOCK_STREAM, 0, socks[i].ptr[0..2]));
         //logf("socks[i] = %s", i, socks[i]);
     }
 
@@ -103,7 +103,7 @@ void main(string[] args) {
         auto a = socks[i][1];
         fiberPongPing(a, s1, s2);
     }
-    runUntilCompletion();
+    runFibers();
     //
     foreach(w; wrs) {
         w.join();

--- a/dfio/tests/ping_pong_thread_half_duplex.d
+++ b/dfio/tests/ping_pong_thread_half_duplex.d
@@ -48,7 +48,7 @@ void main() {
 
    // spawn fiber to read stuff
    spawn(() => reader(socks[1]));
-   runUntilCompletion();
+   runFibers();
    //
    wr.join();
 }

--- a/meeting-notes/1st-sketch.d
+++ b/meeting-notes/1st-sketch.d
@@ -2,16 +2,16 @@
 void spawn(void function() func);
 
 // run fibers until all of them terminate
-void runUntilCompletion();
+void runFibers();
 
 void main(){
     new t1 = new Thread(() {
        ...
-       runUntilCompletion();
+       runFibers();
     });
     new t2 = new Thread(() {
        ...
-       runUntilCompletion();       
+       runFibers();       
     });
     t1.start(); t2.start();
     t1.join();
@@ -40,7 +40,7 @@ ssize_t read(int fd, void *buf, size_t count)
     else return resp; // the easy way out ;)
 }
 
-void runUntilCompletion()
+void runFibers()
 {
     while (alive > 0) { 
         currentFiber = take(queue);

--- a/meeting-notes/1st_compiling_sketch.d
+++ b/meeting-notes/1st_compiling_sketch.d
@@ -22,16 +22,16 @@ import core.atomic;
 void spawn(void function() func);
 
 // run fibers until all of them terminate
-void runUntilCompletion();
+void runFibers();
 
 void main(){
     auto t1 = new Thread(() {
        //...
-       runUntilCompletion();
+       runFibers();
     });
     auto t2 = new Thread(() {
        //...
-       runUntilCompletion();
+       runFibers();
     });
     t1.start(); t2.start();
     t1.join();
@@ -89,7 +89,7 @@ ssize_t read(int fd, void *buf, size_t count)
     else return resp; // the easy way out ;)
 }
 
-void runUntilCompletion()
+void runFibers()
 {
     while (alive > 0) { 
         //currentFiber = take(queue); // TODO implement take

--- a/meeting-notes/3rd_meeting_sketch.d
+++ b/meeting-notes/3rd_meeting_sketch.d
@@ -31,7 +31,7 @@ void main() {
 
    // spawn fiber to read stuff
    spawn(() => reader(socks[1]);
-   runUntilCompletion();
+   runFibers();
    //
    wr.join();
 }

--- a/meeting-notes/4th_meeting_sketch.d
+++ b/meeting-notes/4th_meeting_sketch.d
@@ -42,7 +42,7 @@ void main() {
 
    // spawn fiber to read stuff
    spawn(() => reader(socks[1]));
-   runUntilCompletion();
+   runFibers();
    //
    wr.join();
 }
@@ -57,7 +57,7 @@ void main() {
    wr.start();
    // spawn fiber to read stuff
    spawn(() => reader(socks[1]));
-   runUntilCompletion(); // this we should get rid off eventually too
+   runFibers(); // this we should get rid off eventually too
    //
    wr.join();
 }
@@ -69,7 +69,7 @@ void main() {
    check(socketpair(AF_UNIX, SOCK_STREAM, 0, socks));
    spawn(() => writer(socks[0]));
    spawn(() => reader(socks[1]));
-   runUntilCompletion(); // this we should get rid off eventually too
+   runFibers(); // this we should get rid off eventually too
 }
 
 // The last problem is managing multiple threads with Fibers
@@ -90,6 +90,6 @@ void main(){
     foreach(_; 0..8)
         new Thread(() => {
             spawn(server);
-            runUntilCompletion();
+            runFibers();
         }).start();
 }


### PR DESCRIPTION
Includes previous PR fixes, plus:
- symmetric eventloop w/o the mess of dedicated event thread
- intercept close call to reset firstUse flag

The last one is actually critical, since kernel agressively reuses FDs once they get closed.