### PR TITLE
Add vibe.d http server, sadly it leaks memory in versions 0.8.2+

### DIFF
--- a/dfio/bench/static_http/hello_vibed.d
+++ b/dfio/bench/static_http/hello_vibed.d
@@ -1,0 +1,22 @@
+/+ dub.sdl:
+	name "hello-vibed"
+    dependency "vibe-d" version="~>0.8.2"
+    versions "VibeDefaultMain"
++/
+import vibe.d;
+
+void serve(HTTPServerRequest req, HTTPServerResponse res)
+{
+	res.writeBody("Hello, world!");
+}
+
+shared static this()
+{
+	auto router = new URLRouter;
+	router.get("/", &serve);
+	
+	auto settings = new HTTPServerSettings;
+	settings.port = 8080;
+	
+	listenHTTP(settings, router);
+}


### PR DESCRIPTION
So it starts out fine at around 30k RPS (while our hello is at ~35-36k)
it then hits swap at around 500 concurrent clients on my laptop.

v0.8.2 is actually ~50% faster then recent 0.8.3alpha and leaks a bit
less.

Will measure things tomorrow on my desktop.

To run, use: 
```
dub -b release --single ./hello_vibed.d
```
