### PR TITLE
Cleaning up the obvious, do not reallocate parser on each request

### DIFF
--- a/dfio/Makefile
+++ b/dfio/Makefile
@@ -12,7 +12,7 @@ bench: libdfio.so BlockingQueue.o http-parser
 simple-bench: libdfio.so BlockingQueue.o http-parser
 	$(MAKE) -C bench simple-bench
 
-simple-bench-ldc: DC=ldc2
+simple-bench-ldc: DC=ldmd2
 simple-bench-ldc: DFLAGS=-O3 -O4 -O5 -release -link-defaultlib-shared
 simple-bench-ldc: libdfio.so BlockingQueue.o http-parser
 	$(MAKE) -C bench simple-bench-ldc


### PR DESCRIPTION
Also opted for non-allocating caseinsensitive comparison of strings.

Still, I see that a patch for std.uni is in order to speed up sicmp / icmp for ASCII fast path.

Something on my list to do and help the bigger D world :)