### PR TITLE
Intrusive queue for the win

### DIFF
--- a/dfio/Makefile
+++ b/dfio/Makefile
@@ -1,5 +1,4 @@
-# DFLAGS=-O -release -inline -I~/workspace/dlang/druntime/import/
-DFLAGS=-debug -g -I~/workspace/dlang/druntime/import/ -O -release -inline
+DFLAGS=-g -O -release -inline
 export DFLAGS
 DC=dmd
 export DC


### PR DESCRIPTION
Also we only ever use tryPop so we can avoid conditional variable overhead completely. Still maybe interesting to check codegen later on.

Before:
```
 Number        Requests per second            CPU               RAM
   of     ----------------------------  ----------------  --------------
Clients      min       ave       max      user    kernel  SRV MB  SYS MB    Time
--------  --------  --------  --------  -------  -------  ------  ------  --------
      1,    84217,    85252,    86038,      74,      45,   4.30,    0.0,  18:30:52
     10,    74494,    83440,    88990,      80,      50,   4.32,    0.0,  18:30:56
     20,    88964,    90081,    91560,      71,      37,   4.36,    0.0,  18:30:59
     30,    88080,    89233,    90745,      78,      39,   4.40,    0.0,  18:31:03
     40,    88383,    88820,    89046,      69,      44,   4.44,    0.0,  18:31:06
     50,    85589,    88817,    91307,      71,      40,   4.48,    0.0,  18:31:10
     60,    90692,    91222,    91598,      67,      42,   4.52,    0.0,  18:31:13
     70,    86907,    89512,    91390,      74,      36,   4.56,    0.0,  18:31:17
     80,    89434,    89983,    90258,      71,      40,   4.60,    0.0,  18:31:20
     90,    87932,    89268,    91618,      70,      43,   4.64,    0.0,  18:31:24
    100,    85414,    89090,    90958,      66,      44,   4.68,    0.0,  18:31:27
    110,    86284,    88350,    89881,      66,      46,   4.72,    0.0,  18:31:30
    120,    86895,    88576,    89611,      74,      41,   4.74,    0.0,  18:31:34
    130,    90388,    90615,    90830,      71,      40,   4.80,    0.0,  18:31:37
    140,    83578,    86484,    88409,      66,      47,   4.84,    0.0,  18:31:41
    150,    80429,    84507,    87824,      79,      39,   4.88,    0.0,  18:31:45
    160,    77337,    82095,    85197,      76,      43,   4.92,    0.0,  18:31:48
    170,    80142,    84852,    88277,      76,      49,   4.96,    0.0,  18:31:52
    180,    84628,    86045,    86983,      67,      52,   5.00,    0.0,  18:31:56
    190,    78450,    83065,    86216,      79,      39,   5.04,    0.0,  18:32:00
    200,    76171,    82145,    86447,      70,      48,   5.07,    0.0,  18:32:03
    210,    75272,    79582,    83386,      81,      44,   5.12,    0.0,  18:32:07
    220,    76019,    83424,    87768,      72,      44,   5.16,    0.0,  18:32:11
    230,    77136,    80836,    86373,      78,      52,   5.20,    0.1,  18:32:15
    240,    82318,    85091,    86478,      71,      51,   5.24,    0.0,  18:32:19
    250,    78422,    82103,    84440,      75,      53,   5.28,    0.0,  18:32:22
    260,    75864,    79366,    82884,      75,      46,   5.31,    0.0,  18:32:26
    270,    80683,    82916,    87367,      86,      38,   5.24,    0.0,  18:32:30
    280,    78915,    81389,    85229,      75,      49,   5.39,    0.1,  18:32:34

```
After:
```
 Number        Requests per second            CPU               RAM
   of     ----------------------------  ----------------  --------------
Clients      min       ave       max      user    kernel  SRV MB  SYS MB    Time
--------  --------  --------  --------  -------  -------  ------  ------  --------
      1,    86898,    89250,    91276,      71,      43,   4.18,    0.0,  18:27:26
     10,    93133,    94343,    95874,      64,      41,   4.21,    0.0,  18:27:29
     20,    93112,    94007,    95646,      68,      40,   4.25,    0.0,  18:27:33
     30,    94746,    96271,    97748,      66,      42,   4.29,    0.0,  18:27:36
     40,    89899,    94134,    97911,      64,      38,   4.33,    0.0,  18:27:39
     50,    95260,    96567,    98058,      63,      39,   4.37,    0.0,  18:27:42
     60,    90290,    93792,    95867,      66,      38,   4.41,    0.0,  18:27:46
     70,    90302,    93647,    96338,      67,      44,   4.45,    0.0,  18:27:49
     80,    94317,    96599,    98094,      62,      40,   4.49,    0.0,  18:27:52
     90,    96326,    97370,    98316,      62,      41,   4.53,    0.0,  18:27:55
    100,    95439,    95935,    96528,      71,      34,   4.57,    0.0,  18:27:59
    110,    88112,    93194,    96205,      67,      37,   4.61,    0.0,  18:28:02
    120,    95293,    95871,    96705,      69,      34,   4.65,    0.0,  18:28:05
    130,    92292,    94664,    96521,      68,      36,   4.69,    0.0,  18:28:08
    140,    89273,    89914,    91125,      68,      44,   4.73,    0.0,  18:28:12
    150,    93980,    94873,    95923,      67,      38,   4.77,    0.0,  18:28:15
    160,    86397,    88378,    91006,      74,      37,   5.20,    0.0,  18:28:19
    170,    93303,    94021,    95019,      62,      45,   4.85,    0.0,  18:28:22
    180,    90245,    91258,    92141,      59,      50,   4.89,    0.0,  18:28:25
    190,    88429,    91128,    92994,      62,      46,   4.93,    0.0,  18:28:29
    200,    90846,    91688,    92366,      68,      40,   4.97,    0.0,  18:28:32
```